### PR TITLE
support windows

### DIFF
--- a/log.go
+++ b/log.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -61,7 +60,7 @@ func CrashLog(file string) {
 	if err != nil {
 		log.Println(err.Error())
 	} else {
-		syscall.Dup2(int(f.Fd()), 2)
+		dup2(f, os.Stderr)
 	}
 }
 

--- a/log_posix.go
+++ b/log_posix.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package logging
+
+import (
+	"os"
+	"syscall"
+)
+
+func dup2(oldfd, newfd *os.File) error {
+	return syscall.Dup2(oldfd.Fd(), newfd.Fd())
+}

--- a/log_windows.go
+++ b/log_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package logging
+
+import (
+	"io"
+	"os"
+)
+
+func dup2(oldfd, newfd *os.File) error {
+	go io.Copy(newfd, oldfd)
+	return nil
+}


### PR DESCRIPTION
Windows doesn't have syscall.Dup2(). This is workaround.